### PR TITLE
Fix mobile menu

### DIFF
--- a/css/responsive/desktop.styl
+++ b/css/responsive/desktop.styl
@@ -156,7 +156,7 @@ p.wp-caption-text
 .sub-menu 
   padding-top: 81px
   ul 
-    padding: $margin-basic $margin-small
+    padding: $margin-basic $margin-small $margin-mid
   
 // PROJECT
 

--- a/css/responsive/tablet.styl
+++ b/css/responsive/tablet.styl
@@ -185,7 +185,7 @@ p.wp-caption-text
 .sub-menu 
   padding-top: 72px
   ul 
-    padding: $margin-basic $margin-small
+    padding: $margin-basic $margin-small $margin-mid
   
 #projects-menu
   width: 60%

--- a/css/site.css
+++ b/css/site.css
@@ -794,9 +794,11 @@ a:visited {
   border-bottom: 2px solid #000;
 }
 html {
+  height: 100%;
   color: #000;
 }
 body {
+  height: 100%;
   background-color: #fff;
 }
 img {
@@ -894,6 +896,7 @@ p.wp-caption-text {
 }
 #header.open {
   color: #fff;
+  height: 100%;
 }
 #header.open #main-menu {
   background-color: unset !important;

--- a/css/site.css
+++ b/css/site.css
@@ -920,7 +920,6 @@ p.wp-caption-text {
   line-height: 1;
 }
 .sub-menu {
-  display: none;
   overflow-y: auto;
   position: absolute;
   background-color: #242424;
@@ -930,12 +929,22 @@ p.wp-caption-text {
   z-index: 200;
   text-align: center;
   padding-top: 60px;
+  max-height: 100vh;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+  filter: alpha(opacity=0);
+  opacity: 0;
+  pointer-events: none;
 }
 .sub-menu.active {
   display: block;
+  -ms-filter: none;
+  -webkit-filter: none;
+          filter: none;
+  opacity: 1;
+  pointer-events: auto;
 }
 .sub-menu ul {
-  padding: 44px 22px;
+  padding: 44px 22px 77px;
 }
 .sub-menu li {
   margin-bottom: 0;
@@ -950,8 +959,6 @@ p.wp-caption-text {
   border-bottom: 3px solid #fff;
 }
 #projects-menu {
-  width: 75%;
-  height: 100%;
   width: 75vw;
   height: 100vh;
 }
@@ -1274,7 +1281,7 @@ p.wp-caption-text {
     padding-top: 72px;
   }
   .sub-menu ul {
-    padding: 52px 26px;
+    padding: 52px 26px 91px;
   }
   #projects-menu {
     width: 60%;
@@ -1507,7 +1514,7 @@ p.wp-caption-text {
     padding-top: 81px;
   }
   .sub-menu ul {
-    padding: 60px 30px;
+    padding: 60px 30px 105px;
   }
   #project-text-holder p {
     width: 1000px;

--- a/css/site.css
+++ b/css/site.css
@@ -73,17 +73,17 @@ ul.u-inline-list li {
   vertical-align: middle;
 }
 .u-flex-center {
-  display: -webkit-box;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-align: center;
+  -webkit-align-items: center;
   -ms-align-items: center;
   -ms-flex-align: center;
       align-items: center;
+  -webkit-justify-content: center;
   -ms-justify-content: center;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
 }
 @font-face {
   font-family: 'Moderat';
@@ -491,59 +491,58 @@ th {
 }
 .row {
   box-sizing: border-box;
-  display: -webkit-box;
+  display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex: 0 1 auto;
   -ms-flex: 0 1 auto;
-  -webkit-box-flex: 0;
-          flex: 0 1 auto;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
+  flex: 0 1 auto;
+  -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
 }
 .row.reverse {
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: reverse;
+  -webkit-flex-direction: row-reverse;
   -ms-flex-direction: row-reverse;
   flex-direction: row-reverse;
 }
 .justify-start {
+  -webkit-justify-content: flex-start;
   -ms-justify-content: flex-start;
-  -webkit-box-pack: start;
-      -ms-flex-pack: start;
-          justify-content: flex-start;
+  -ms-flex-pack: start;
+      justify-content: flex-start;
 }
 .justify-center {
+  -webkit-justify-content: center;
   -ms-justify-content: center;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
+  -ms-flex-pack: center;
+      justify-content: center;
 }
 .justify-end {
+  -webkit-justify-content: flex-end;
   -ms-justify-content: flex-end;
-  -webkit-box-pack: end;
-      -ms-flex-pack: end;
-          justify-content: flex-end;
+  -ms-flex-pack: end;
+      justify-content: flex-end;
 }
 .align-start {
-  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
   -ms-align-items: flex-start;
   -ms-flex-align: start;
       -ms-grid-row-align: flex-start;
       align-items: flex-start;
 }
 .align-center {
-  -webkit-box-align: center;
+  -webkit-align-items: center;
   -ms-align-items: center;
   -ms-flex-align: center;
       -ms-grid-row-align: center;
       align-items: center;
 }
 .align-end {
-  -webkit-box-align: end;
+  -webkit-align-items: flex-end;
   -ms-align-items: flex-end;
   -ms-flex-align: end;
       -ms-grid-row-align: flex-end;
@@ -551,24 +550,27 @@ th {
 }
 .align-content-start {
   -ms-align-content: flex-start;
-  -ms-flex-line-pack: start;
-      align-content: flex-start;
+  -webkit-align-content: flex-start;
+      -ms-flex-line-pack: start;
+          align-content: flex-start;
 }
 .align-content-center {
   -ms-align-content: center;
-  -ms-flex-line-pack: center;
-      align-content: center;
+  -webkit-align-content: center;
+      -ms-flex-line-pack: center;
+          align-content: center;
 }
 .align-content-end {
   -ms-align-content: flex-end;
-  -ms-flex-line-pack: end;
-      align-content: flex-end;
+  -webkit-align-content: flex-end;
+      -ms-flex-line-pack: end;
+          align-content: flex-end;
 }
 .col {
   position: relative;
+  -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
-  -webkit-box-flex: 1;
-          flex: 1 1 auto;
+  flex: 1 1 auto;
   box-sizing: border-box;
   max-width: 100%;
   padding: 0 11px;
@@ -619,74 +621,86 @@ th {
 }
 .col-s-1 {
   -ms-flex-basis: 8.333333333333334%;
-  -ms-flex-preferred-size: 8.333333333333334%;
-      flex-basis: 8.333333333333334%;
+  -webkit-flex-basis: 8.333333333333334%;
+      -ms-flex-preferred-size: 8.333333333333334%;
+          flex-basis: 8.333333333333334%;
   max-width: 8.333333333333334%;
 }
 .col-s-2 {
   -ms-flex-basis: 16.666666666666668%;
-  -ms-flex-preferred-size: 16.666666666666668%;
-      flex-basis: 16.666666666666668%;
+  -webkit-flex-basis: 16.666666666666668%;
+      -ms-flex-preferred-size: 16.666666666666668%;
+          flex-basis: 16.666666666666668%;
   max-width: 16.666666666666668%;
 }
 .col-s-3 {
   -ms-flex-basis: 25%;
-  -ms-flex-preferred-size: 25%;
-      flex-basis: 25%;
+  -webkit-flex-basis: 25%;
+      -ms-flex-preferred-size: 25%;
+          flex-basis: 25%;
   max-width: 25%;
 }
 .col-s-4 {
   -ms-flex-basis: 33.333333333333336%;
-  -ms-flex-preferred-size: 33.333333333333336%;
-      flex-basis: 33.333333333333336%;
+  -webkit-flex-basis: 33.333333333333336%;
+      -ms-flex-preferred-size: 33.333333333333336%;
+          flex-basis: 33.333333333333336%;
   max-width: 33.333333333333336%;
 }
 .col-s-5 {
   -ms-flex-basis: 41.66666666666667%;
-  -ms-flex-preferred-size: 41.66666666666667%;
-      flex-basis: 41.66666666666667%;
+  -webkit-flex-basis: 41.66666666666667%;
+      -ms-flex-preferred-size: 41.66666666666667%;
+          flex-basis: 41.66666666666667%;
   max-width: 41.66666666666667%;
 }
 .col-s-6 {
   -ms-flex-basis: 50%;
-  -ms-flex-preferred-size: 50%;
-      flex-basis: 50%;
+  -webkit-flex-basis: 50%;
+      -ms-flex-preferred-size: 50%;
+          flex-basis: 50%;
   max-width: 50%;
 }
 .col-s-7 {
   -ms-flex-basis: 58.333333333333336%;
-  -ms-flex-preferred-size: 58.333333333333336%;
-      flex-basis: 58.333333333333336%;
+  -webkit-flex-basis: 58.333333333333336%;
+      -ms-flex-preferred-size: 58.333333333333336%;
+          flex-basis: 58.333333333333336%;
   max-width: 58.333333333333336%;
 }
 .col-s-8 {
   -ms-flex-basis: 66.66666666666667%;
-  -ms-flex-preferred-size: 66.66666666666667%;
-      flex-basis: 66.66666666666667%;
+  -webkit-flex-basis: 66.66666666666667%;
+      -ms-flex-preferred-size: 66.66666666666667%;
+          flex-basis: 66.66666666666667%;
   max-width: 66.66666666666667%;
 }
 .col-s-9 {
   -ms-flex-basis: 75%;
-  -ms-flex-preferred-size: 75%;
-      flex-basis: 75%;
+  -webkit-flex-basis: 75%;
+      -ms-flex-preferred-size: 75%;
+          flex-basis: 75%;
   max-width: 75%;
 }
 .col-s-10 {
   -ms-flex-basis: 83.33333333333334%;
-  -ms-flex-preferred-size: 83.33333333333334%;
-      flex-basis: 83.33333333333334%;
+  -webkit-flex-basis: 83.33333333333334%;
+      -ms-flex-preferred-size: 83.33333333333334%;
+          flex-basis: 83.33333333333334%;
   max-width: 83.33333333333334%;
 }
 .col-s-11 {
   -ms-flex-basis: 91.66666666666667%;
-  -ms-flex-preferred-size: 91.66666666666667%;
-      flex-basis: 91.66666666666667%;
+  -webkit-flex-basis: 91.66666666666667%;
+      -ms-flex-preferred-size: 91.66666666666667%;
+          flex-basis: 91.66666666666667%;
   max-width: 91.66666666666667%;
 }
 .col-s-12 {
   -ms-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-      flex-basis: 100%;
+  -webkit-flex-basis: 100%;
+      -ms-flex-preferred-size: 100%;
+          flex-basis: 100%;
   max-width: 100%;
 }
 html {
@@ -729,8 +743,10 @@ p {
 }
 .font-expanded {
   -webkit-transform-origin: top;
+  -ms-transform-origin: top;
   transform-origin: top;
   -webkit-transform: scaleY(0.7);
+  -ms-transform: scaleY(0.7);
   transform: scaleY(0.7);
 }
 .font-expanded.underline-links a:link,
@@ -1088,74 +1104,86 @@ p.wp-caption-text {
   }
   .col-m-1 {
     -ms-flex-basis: 8.333333333333334%;
-    -ms-flex-preferred-size: 8.333333333333334%;
-        flex-basis: 8.333333333333334%;
+    -webkit-flex-basis: 8.333333333333334%;
+        -ms-flex-preferred-size: 8.333333333333334%;
+            flex-basis: 8.333333333333334%;
     max-width: 8.333333333333334%;
   }
   .col-m-2 {
     -ms-flex-basis: 16.666666666666668%;
-    -ms-flex-preferred-size: 16.666666666666668%;
-        flex-basis: 16.666666666666668%;
+    -webkit-flex-basis: 16.666666666666668%;
+        -ms-flex-preferred-size: 16.666666666666668%;
+            flex-basis: 16.666666666666668%;
     max-width: 16.666666666666668%;
   }
   .col-m-3 {
     -ms-flex-basis: 25%;
-    -ms-flex-preferred-size: 25%;
-        flex-basis: 25%;
+    -webkit-flex-basis: 25%;
+        -ms-flex-preferred-size: 25%;
+            flex-basis: 25%;
     max-width: 25%;
   }
   .col-m-4 {
     -ms-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-        flex-basis: 33.333333333333336%;
+    -webkit-flex-basis: 33.333333333333336%;
+        -ms-flex-preferred-size: 33.333333333333336%;
+            flex-basis: 33.333333333333336%;
     max-width: 33.333333333333336%;
   }
   .col-m-5 {
     -ms-flex-basis: 41.66666666666667%;
-    -ms-flex-preferred-size: 41.66666666666667%;
-        flex-basis: 41.66666666666667%;
+    -webkit-flex-basis: 41.66666666666667%;
+        -ms-flex-preferred-size: 41.66666666666667%;
+            flex-basis: 41.66666666666667%;
     max-width: 41.66666666666667%;
   }
   .col-m-6 {
     -ms-flex-basis: 50%;
-    -ms-flex-preferred-size: 50%;
-        flex-basis: 50%;
+    -webkit-flex-basis: 50%;
+        -ms-flex-preferred-size: 50%;
+            flex-basis: 50%;
     max-width: 50%;
   }
   .col-m-7 {
     -ms-flex-basis: 58.333333333333336%;
-    -ms-flex-preferred-size: 58.333333333333336%;
-        flex-basis: 58.333333333333336%;
+    -webkit-flex-basis: 58.333333333333336%;
+        -ms-flex-preferred-size: 58.333333333333336%;
+            flex-basis: 58.333333333333336%;
     max-width: 58.333333333333336%;
   }
   .col-m-8 {
     -ms-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-        flex-basis: 66.66666666666667%;
+    -webkit-flex-basis: 66.66666666666667%;
+        -ms-flex-preferred-size: 66.66666666666667%;
+            flex-basis: 66.66666666666667%;
     max-width: 66.66666666666667%;
   }
   .col-m-9 {
     -ms-flex-basis: 75%;
-    -ms-flex-preferred-size: 75%;
-        flex-basis: 75%;
+    -webkit-flex-basis: 75%;
+        -ms-flex-preferred-size: 75%;
+            flex-basis: 75%;
     max-width: 75%;
   }
   .col-m-10 {
     -ms-flex-basis: 83.33333333333334%;
-    -ms-flex-preferred-size: 83.33333333333334%;
-        flex-basis: 83.33333333333334%;
+    -webkit-flex-basis: 83.33333333333334%;
+        -ms-flex-preferred-size: 83.33333333333334%;
+            flex-basis: 83.33333333333334%;
     max-width: 83.33333333333334%;
   }
   .col-m-11 {
     -ms-flex-basis: 91.66666666666667%;
-    -ms-flex-preferred-size: 91.66666666666667%;
-        flex-basis: 91.66666666666667%;
+    -webkit-flex-basis: 91.66666666666667%;
+        -ms-flex-preferred-size: 91.66666666666667%;
+            flex-basis: 91.66666666666667%;
     max-width: 91.66666666666667%;
   }
   .col-m-12 {
     -ms-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    -webkit-flex-basis: 100%;
+        -ms-flex-preferred-size: 100%;
+            flex-basis: 100%;
     max-width: 100%;
   }
   html {
@@ -1344,74 +1372,86 @@ p.wp-caption-text {
   }
   .col-l-1 {
     -ms-flex-basis: 8.333333333333334%;
-    -ms-flex-preferred-size: 8.333333333333334%;
-        flex-basis: 8.333333333333334%;
+    -webkit-flex-basis: 8.333333333333334%;
+        -ms-flex-preferred-size: 8.333333333333334%;
+            flex-basis: 8.333333333333334%;
     max-width: 8.333333333333334%;
   }
   .col-l-2 {
     -ms-flex-basis: 16.666666666666668%;
-    -ms-flex-preferred-size: 16.666666666666668%;
-        flex-basis: 16.666666666666668%;
+    -webkit-flex-basis: 16.666666666666668%;
+        -ms-flex-preferred-size: 16.666666666666668%;
+            flex-basis: 16.666666666666668%;
     max-width: 16.666666666666668%;
   }
   .col-l-3 {
     -ms-flex-basis: 25%;
-    -ms-flex-preferred-size: 25%;
-        flex-basis: 25%;
+    -webkit-flex-basis: 25%;
+        -ms-flex-preferred-size: 25%;
+            flex-basis: 25%;
     max-width: 25%;
   }
   .col-l-4 {
     -ms-flex-basis: 33.333333333333336%;
-    -ms-flex-preferred-size: 33.333333333333336%;
-        flex-basis: 33.333333333333336%;
+    -webkit-flex-basis: 33.333333333333336%;
+        -ms-flex-preferred-size: 33.333333333333336%;
+            flex-basis: 33.333333333333336%;
     max-width: 33.333333333333336%;
   }
   .col-l-5 {
     -ms-flex-basis: 41.66666666666667%;
-    -ms-flex-preferred-size: 41.66666666666667%;
-        flex-basis: 41.66666666666667%;
+    -webkit-flex-basis: 41.66666666666667%;
+        -ms-flex-preferred-size: 41.66666666666667%;
+            flex-basis: 41.66666666666667%;
     max-width: 41.66666666666667%;
   }
   .col-l-6 {
     -ms-flex-basis: 50%;
-    -ms-flex-preferred-size: 50%;
-        flex-basis: 50%;
+    -webkit-flex-basis: 50%;
+        -ms-flex-preferred-size: 50%;
+            flex-basis: 50%;
     max-width: 50%;
   }
   .col-l-7 {
     -ms-flex-basis: 58.333333333333336%;
-    -ms-flex-preferred-size: 58.333333333333336%;
-        flex-basis: 58.333333333333336%;
+    -webkit-flex-basis: 58.333333333333336%;
+        -ms-flex-preferred-size: 58.333333333333336%;
+            flex-basis: 58.333333333333336%;
     max-width: 58.333333333333336%;
   }
   .col-l-8 {
     -ms-flex-basis: 66.66666666666667%;
-    -ms-flex-preferred-size: 66.66666666666667%;
-        flex-basis: 66.66666666666667%;
+    -webkit-flex-basis: 66.66666666666667%;
+        -ms-flex-preferred-size: 66.66666666666667%;
+            flex-basis: 66.66666666666667%;
     max-width: 66.66666666666667%;
   }
   .col-l-9 {
     -ms-flex-basis: 75%;
-    -ms-flex-preferred-size: 75%;
-        flex-basis: 75%;
+    -webkit-flex-basis: 75%;
+        -ms-flex-preferred-size: 75%;
+            flex-basis: 75%;
     max-width: 75%;
   }
   .col-l-10 {
     -ms-flex-basis: 83.33333333333334%;
-    -ms-flex-preferred-size: 83.33333333333334%;
-        flex-basis: 83.33333333333334%;
+    -webkit-flex-basis: 83.33333333333334%;
+        -ms-flex-preferred-size: 83.33333333333334%;
+            flex-basis: 83.33333333333334%;
     max-width: 83.33333333333334%;
   }
   .col-l-11 {
     -ms-flex-basis: 91.66666666666667%;
-    -ms-flex-preferred-size: 91.66666666666667%;
-        flex-basis: 91.66666666666667%;
+    -webkit-flex-basis: 91.66666666666667%;
+        -ms-flex-preferred-size: 91.66666666666667%;
+            flex-basis: 91.66666666666667%;
     max-width: 91.66666666666667%;
   }
   .col-l-12 {
     -ms-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-        flex-basis: 100%;
+    -webkit-flex-basis: 100%;
+        -ms-flex-preferred-size: 100%;
+            flex-basis: 100%;
     max-width: 100%;
   }
   .font-size-large {

--- a/css/site.css
+++ b/css/site.css
@@ -794,11 +794,9 @@ a:visited {
   border-bottom: 2px solid #000;
 }
 html {
-  height: 100%;
   color: #000;
 }
 body {
-  height: 100%;
   background-color: #fff;
 }
 img {
@@ -954,6 +952,8 @@ p.wp-caption-text {
 #projects-menu {
   width: 75%;
   height: 100%;
+  width: 75vw;
+  height: 100vh;
 }
 #sort-menu {
   width: 100%;

--- a/css/site.styl
+++ b/css/site.styl
@@ -35,7 +35,7 @@ $gutter = 22px
 .container
   margin: 0 auto
   width: 96%
-  max-width: 2400px 
+  max-width: 2400px
 
 .row
   box-sizing: border-box

--- a/css/site.styl
+++ b/css/site.styl
@@ -244,11 +244,13 @@ a:visited
 // ******************************************************
 
 // BASIC
-
+  
 html
+  height: 100%
   color: $color-black
   
 body
+  height: 100%
   background-color: $color-white
 
 img
@@ -360,6 +362,7 @@ p.wp-caption-text
   z-index: 100
   &.open
     color: $color-white
+    height: 100%
     #main-menu
       background-color: unset !important
     .menu-item

--- a/css/site.styl
+++ b/css/site.styl
@@ -341,6 +341,8 @@ img
 
 // ******************************************************
 
+$header-height = 60px
+
 .caption
   width: 70%
   margin-left: auto
@@ -381,8 +383,7 @@ p.wp-caption-text
   h1 
     line-height: 1
 
-.sub-menu 
-  display: none
+.sub-menu
   overflow-y: auto
   position: absolute
   background-color: $color-black-soft
@@ -391,11 +392,16 @@ p.wp-caption-text
   left: 0
   z-index: 200
   text-align: center
-  padding-top: 60px
+  padding-top: $header-height
+  max-height: 100vh
+  opacity: 0
+  pointer-events: none
   &.active
     display: block
+    opacity: 1
+    pointer-events: auto
   ul 
-    padding: $margin-basic $margin-small
+    padding: $margin-basic $margin-small $margin-mid
   li
     margin-bottom: 0
     a:hover
@@ -407,8 +413,6 @@ p.wp-caption-text
     border-bottom: ($border-width + 1) solid $color-white
     
 #projects-menu
-  width: 75%
-  height: 100%
   width: 75vw
   height: 100vh
   

--- a/css/site.styl
+++ b/css/site.styl
@@ -246,11 +246,9 @@ a:visited
 // BASIC
   
 html
-  height: 100%
   color: $color-black
   
 body
-  height: 100%
   background-color: $color-white
 
 img
@@ -411,6 +409,8 @@ p.wp-caption-text
 #projects-menu
   width: 75%
   height: 100%
+  width: 75vw
+  height: 100vh
   
 #sort-menu
   width: 100%

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,9 @@ gulp.task('style', function() {
       ],
     }))
   .on('error', errorNotify)
-  .pipe(autoprefixer())
+  .pipe(autoprefixer({
+    browsers: ['last 5 versions'],
+  }))
   .on('error', errorNotify)
   .pipe(gulp.dest('css'))
   .pipe(rename({suffix: '.min'}))

--- a/header.php
+++ b/header.php
@@ -100,7 +100,8 @@ if (count($home_items) > 0) {
 if (count($posts) > 0) {
 ?>
       <div id="projects-menu" class="sub-menu font-size-extra font-bold">
-        <ul class="font-expanded">
+        <div class="font-expanded-holder">
+          <ul class="font-expanded">
 <?php
   foreach($posts as $post) {
     setup_postdata($post);
@@ -112,7 +113,8 @@ if (count($posts) > 0) {
   }
   wp_reset_postdata();
 ?>
-        </ul>
+          </ul>
+        </div>
       </div>
 <?php
 }
@@ -123,7 +125,8 @@ if (count($posts) > 0) {
 if ($cat_array) {
 ?>
       <div id="sort-menu" class="sub-menu font-size-large font-bold">
-        <ul class="u-inline-list font-expanded">
+        <div class="font-expanded-holder">
+          <ul class="u-inline-list font-expanded">
 <?php
   $cat_count = count($cat_array);
   $cat_num = 0; 
@@ -142,7 +145,8 @@ if ($cat_array) {
 <?php
   }
 ?>
-        </ul>
+          </ul>
+        </div>
       </div>
 <?php
 }

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@ get_header();
 
   <!-- main posts loop -->
   <section id="posts" class="container">
-    <div class="row">
+    <div class="row justify-center">
 
 <?php
 $args = array (

--- a/js/main.js
+++ b/js/main.js
@@ -14,12 +14,14 @@ Site = {
 
     _this.Header.init();
 
+    _this.Layout.fontExpandedHeight();
+
   },
 
   onResize: function() {
     var _this = this;
 
-    _this.Header.menuMaxHeight();
+    _this.Layout.fontExpandedHeight();
   },
 
   fixWidows: function() {
@@ -32,6 +34,14 @@ Site = {
   },
 };
 
+Site.Layout = {
+  fontExpandedHeight: function() {
+    $('.font-expanded').each(function(){
+      $(this).parent('.font-expanded-holder').css('height', $(this).outerHeight() * 0.7);
+    })
+  }
+};
+
 Site.Header = {
   $header: $('#header'),
   init: function() {
@@ -40,8 +50,6 @@ Site.Header = {
     if ($('.menu-trigger').length) {
       _this.bindMenuToggles();
     }
-
-    _this.menuMaxHeight();
   },
 
   bindMenuToggles: function() {
@@ -93,21 +101,6 @@ Site.Header = {
       _this.$header.removeClass('projects-open sort-open');
       _this.$header.addClass('open ' + menuName + '-open');
     } 
-  },
-
-  menuMaxHeight: function() {
-    var _this = this;
-    var maxHeight;
-
-    if ($('.sub-menu.active').length) {
-      $('.sub-menu.active');
-      maxHeight = $(window).height() - _this.$header.outerHeight(true);
-      $('.sub-menu.active');
-    } else {
-      maxHeight = $(window).height() - _this.$header.outerHeight(true);
-    }
-
-    $('.sub-menu').css('max-height', maxHeight);
   }
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -62,9 +62,10 @@ Site.Header = {
       _this.toggleMenu(menu);
     });
 
-    $(document).bind('click', function(event) {
-      if (!$(event.target).is('#header, #header *')) {
+    $('#header').bind('click', function(event) {
+      if (!$(event.target).is('#header *')) {
         _this.closeMenu();
+        return false;
       }
     });
   },

--- a/single-conversation.php
+++ b/single-conversation.php
@@ -13,7 +13,7 @@ get_header();
 
       <div class="col col-s-12 col-m-6 text-line-length">
         <h1 class="font-size-mid margin-bottom-1rem">
-          <?php the_title(); ?>
+          <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
         </h1>
 <?php
 $details = get_post_meta($post->ID, '_igv_conversation_details', true);

--- a/single.php
+++ b/single.php
@@ -29,7 +29,7 @@ if (!empty($tagline)) {
 <?php
 if (get_the_content()) {
 ?>
-        <div id="project-text-holder" class="col col-s-12 text-align-center font-size-large font-bold underline-links font-expanded-holder">
+        <div id="project-text-holder" class="col col-s-12 text-align-center font-size-large font-bold underline-links font-expanded-holder margin-bottom-basic">
           <div class="font-expanded">
             <?php the_content(); ?>
           </div>

--- a/single.php
+++ b/single.php
@@ -14,10 +14,12 @@ $tagline = get_post_meta($post->ID, '_igv_tagline', true);
 $images = get_post_meta($post->ID, '_igv_image_gallery', true);
 ?>
 
-      <article <?php post_class('row'); ?>>
+      <article <?php post_class('row justify-center'); ?>>
 
         <div class="col col-s-12 text-align-center">
-          <h1 class="font-size-mid"><?php the_title(); ?></h1>
+          <h1 class="font-size-mid">
+            <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+          </h1>
 <?php
 if (!empty($tagline)) {
 ?>

--- a/single.php
+++ b/single.php
@@ -29,7 +29,11 @@ if (!empty($tagline)) {
 <?php
 if (get_the_content()) {
 ?>
-        <div id="project-text-holder" class="col col-s-12 text-align-center font-size-large font-bold underline-links font-expanded"><?php the_content(); ?></div>
+        <div id="project-text-holder" class="col col-s-12 text-align-center font-size-large font-bold underline-links font-expanded-holder">
+          <div class="font-expanded">
+            <?php the_content(); ?>
+          </div>
+        </div>
 <?php
 }
 


### PR DESCRIPTION
close #50 
- fix click-off menu toggle for mobile
- fix project menu height on mobile. using height: 100% was making it 100% - the height of mobile Safari browser bars
- use JS func to set correct height for font-expanded elems on parent elem
- fix margin-bottom for the_content font-expended elem 
- add browser support to autoprefixer
- justify feed items to center. useful when a half-width item is between two full width items
- add missing links to single template titles
- gulp build to update browser support in css
